### PR TITLE
Add 'py3[4567]' to 'tox.ini', drop 'py26'.

### DIFF
--- a/repoze/catalog/query.py
+++ b/repoze/catalog/query.py
@@ -36,7 +36,7 @@ class Query(object):
         return ()
 
     def print_tree(self, out=sys.stdout, level=0):
-        print('  ' * level + str(self), file=out)
+        out.write(u'{}{}\n'.format(u'  ' * level, str(self)))
         for child in self.iter_children():
             child.print_tree(out, level + 1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py26,py27,cover,docs
+    py27,py34,py35,py36,py37cover,docs
 
 [testenv]
 commands = 
@@ -8,8 +8,6 @@ commands =
 deps =
     ZODB3
     ZConfig
-    virtualenv
-    setuptools-git
 
 [testenv:cover]
 basepython =
@@ -19,11 +17,9 @@ commands =
 deps =
     ZODB3
     ZConfig
-    virtualenv
     nose
     coverage
     nosexcover
-    setuptools-git
 
 # we separate coverage into its own testenv because a) "last run wins" wrt
 # cobertura jenkins reporting and b) pypy and jython can't handle any
@@ -31,7 +27,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python2.6
+    python3.6
 commands = 
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
Also, use Python 2.7-compatible spelling for `print(..., file=out)` in `Query.print_tree`.